### PR TITLE
Fix some typos and "it's" misuse

### DIFF
--- a/doc/base_module/ext/jquery/jquery-ui-1.12.1/jquery-ui.js
+++ b/doc/base_module/ext/jquery/jquery-ui-1.12.1/jquery-ui.js
@@ -9945,7 +9945,7 @@ $.widget( "ui.draggable", $.ui.mouse, {
 
 		// This is a special case where we need to modify a offset calculated on start, since the
 		// following happened:
-		// 1. The position of the helper is absolute, so it's position is calculated based on the
+		// 1. The position of the helper is absolute, so its position is calculated based on the
 		// next positioned parent
 		// 2. The actual offset parent is a child of the scroll parent, and the scroll parent isn't
 		// the document, which means that the scroll is included in the initial calculation of the
@@ -16310,7 +16310,7 @@ var widgetsSortable = $.widget( "ui.sortable", $.ui.mouse, {
 
 		// This is a special case where we need to modify a offset calculated on start, since the
 		// following happened:
-		// 1. The position of the helper is absolute, so it's position is calculated based on the
+		// 1. The position of the helper is absolute, so its position is calculated based on the
 		// next positioned parent
 		// 2. The actual offset parent is a child of the scroll parent, and the scroll parent isn't
 		// the document, which means that the scroll is included in the initial calculation of the

--- a/doc/base_module/kt_js/search_targets.js
+++ b/doc/base_module/kt_js/search_targets.js
@@ -3,7 +3,7 @@ var search_targets =
 
   ["1 Introduction", [
     ["base", "1001", "Material Definition Language (MDL) enables users to define the reflective, transmissive, emissive and volumetric properties of objects. For details regarding the elemental distribution functions and operations, please see the MDL specification."],
-    ["base", "1002", "The module <tt>base.mdl</tt> provides a set of texturing functions covering the whole range from bitmap to procedural texturing. In addition, module <tt>base.mdl</tt> provides helper functions to make some common tasks easy, as well as provide backwards compatibility support for some legacy parameter semantics."]
+    ["base", "1002", "The module <tt>base.mdl</tt> provides a set of texturing functions covering the whole range from bitmap to procedural texturing. In addition, module <tt>base.mdl</tt> provides helper functions to make some common tasks easy, as well as provide backward compatibility support for some legacy parameter semantics."]
   ]],
   ["2.1 Texturing functions", [
     ["base", "1003", "The main purpose of the module <tt>mdl</tt> is to provide material creators with a comprehensive set of texturing functions to spatial variations to their materials."],
@@ -1756,7 +1756,7 @@ var search_targets =
     ["base", "2903", "<tt>bool</tt>"],
     ["base", "2904", "<tt>false</tt>"],
     ["base", "2906", "no"],
-    ["base", "2907", "Allows backwards compatibility with mia material"]
+    ["base", "2907", "Allows backward compatibility with mia material"]
   ]]
 ];
 

--- a/doc/base_module/pages/base.html
+++ b/doc/base_module/pages/base.html
@@ -19,7 +19,7 @@ and operations, please see the MDL specification.</p>
 <p id="1002">The module <span class="monospace">base.mdl</span> provides a set of texturing functions covering
 the whole range from bitmap to procedural texturing. In addition,
 module <span class="monospace">base.mdl</span> provides helper functions to make some common tasks
-easy, as well as provide backwards compatibility support for some
+easy, as well as provide backward compatibility support for some
 legacy parameter semantics.</p>
 
 
@@ -3037,7 +3037,7 @@ still retaining the alignment information.</p>
 <td id="2904" class="lhpos tvpos tline rline bline lline" style="padding:0.2em 0.5em;"><span class="monospace">false</span></td>
 <td id="2905" class="lhpos tvpos tline rline bline lline" style="padding:0.2em 0.5em;">&nbsp;</td>
 <td id="2906" class="lhpos tvpos tline rline bline lline" style="padding:0.2em 0.5em;">no</td>
-<td id="2907" class="lhpos tvpos tline rline bline lline" style="padding:0.2em 0.5em;">Allows backwards compatibility with mia material</td>
+<td id="2907" class="lhpos tvpos tline rline bline lline" style="padding:0.2em 0.5em;">Allows backward compatibility with mia material</td>
 </tr>
 </table>
 

--- a/doc/baseapi/version.dox
+++ b/doc/baseapi/version.dox
@@ -36,7 +36,7 @@ compatibility between different versions.
 \if SHARED_LIB_VERSION
 \section mi_base_version_api API Version of a Shared Library
 
-<b>This section does currently not apply. It will be reviewed towards
+<b>This section does currently not apply. It will be reviewed toward
 the end of the Base API development</b>
 
 Assuming the API is provided in the form of a shared library (also

--- a/doc/core_definitions/ext/jquery/jquery-ui-1.12.1/jquery-ui.js
+++ b/doc/core_definitions/ext/jquery/jquery-ui-1.12.1/jquery-ui.js
@@ -9945,7 +9945,7 @@ $.widget( "ui.draggable", $.ui.mouse, {
 
 		// This is a special case where we need to modify a offset calculated on start, since the
 		// following happened:
-		// 1. The position of the helper is absolute, so it's position is calculated based on the
+		// 1. The position of the helper is absolute, so its position is calculated based on the
 		// next positioned parent
 		// 2. The actual offset parent is a child of the scroll parent, and the scroll parent isn't
 		// the document, which means that the scroll is included in the initial calculation of the
@@ -16310,7 +16310,7 @@ var widgetsSortable = $.widget( "ui.sortable", $.ui.mouse, {
 
 		// This is a special case where we need to modify a offset calculated on start, since the
 		// following happened:
-		// 1. The position of the helper is absolute, so it's position is calculated based on the
+		// 1. The position of the helper is absolute, so its position is calculated based on the
 		// next positioned parent
 		// 2. The actual offset parent is a child of the scroll parent, and the scroll parent isn't
 		// the document, which means that the scroll is included in the initial calculation of the

--- a/doc/core_definitions/kt_js/search_targets.js
+++ b/doc/core_definitions/kt_js/search_targets.js
@@ -2,7 +2,7 @@ var search_targets =
 [/*jshint multistr: true */
 
   ["1 Introduction", [
-    ["definitions", "1001", "The Material Definition Language (MDL) module <tt>nvidia::core_definitions</tt> contains a collection of MDL materials that can either be used independently ( <i>simple materials </i>) or in combination with other materials through the use of <i>material combiners </i> and <i>material modifiers </i>. <i>Texturing functions </i> provide further control and refinement of material parameter values. Together, materials, combiners, modfiers and the texturing functions can simulate complex, real-world models of appearance."]
+    ["definitions", "1001", "The Material Definition Language (MDL) module <tt>nvidia::core_definitions</tt> contains a collection of MDL materials that can either be used independently ( <i>simple materials </i>) or in combination with other materials through the use of <i>material combiners </i> and <i>material modifiers </i>. <i>Texturing functions </i> provide further control and refinement of material parameter values. Together, materials, combiners, modifiers and the texturing functions can simulate complex, real-world models of appearance."]
   ]],
   ["2.1 Simple materials", [
     ["definitions", "1002", "Simple materials can either be used directly to model real world materials with matching behavior or can be used as components when creating more complex materials using material combiners or material modifiers."]
@@ -281,7 +281,7 @@ var search_targets =
     ["definitions", "1257", "Metallic material"],
     ["definitions", "1258", "bool"],
     ["definitions", "1259", "false"],
-    ["definitions", "1260", "If true, reflection will be colored and independent of view direction. If false, reflection will be white and direction dependent. Directional dependence is in this case based on the index of refraction (Fresnell effect)."],
+    ["definitions", "1260", "If true, reflection will be colored and independent of view direction. If false, reflection will be white and direction dependent. Directional dependence is in this case based on the index of refraction (Fresnel effect)."],
     ["definitions", "1261", "Reflection weight"],
     ["definitions", "1262", "float"],
     ["definitions", "1263", "1.0"],
@@ -317,7 +317,7 @@ var search_targets =
     ["definitions", "1293", "Transmission weight"],
     ["definitions", "1294", "float"],
     ["definitions", "1295", "0.0"],
-    ["definitions", "1296", "Weights how much light passes through the object vs it's diffuse reflectivity Values must be between 0.0 and 1.0."],
+    ["definitions", "1296", "Weights how much light passes through the object vs its diffuse reflectivity Values must be between 0.0 and 1.0."],
     ["definitions", "1297", "IOR"],
     ["definitions", "1298", "float"],
     ["definitions", "1299", "1.5"],
@@ -373,7 +373,7 @@ var search_targets =
     ["definitions", "1347", "IOR"],
     ["definitions", "1348", "float"],
     ["definitions", "1349", "1.6"],
-    ["definitions", "1350", "termines reflectivity of the clear coat. Realistic values are between 1.0 and 4.0."],
+    ["definitions", "1350", "determines reflectivity of the clear coat. Realistic values are between 1.0 and 4.0."],
     ["definitions", "1351", "Coat roughness"],
     ["definitions", "1352", "float"],
     ["definitions", "1353", "0.0"],
@@ -440,14 +440,14 @@ var search_targets =
     ["definitions", "1408", "Reflection weight"],
     ["definitions", "1409", "float"],
     ["definitions", "1410", "0.3"],
-    ["definitions", "1411", "The oacity of the metallic coat. Values must be between 0.0 and 1.0."],
+    ["definitions", "1411", "The opacity of the metallic coat. Values must be between 0.0 and 1.0."],
     ["definitions", "1412", "Bumps"],
     ["definitions", "1413", "float3"],
     ["definitions", "1414", "no bumps"],
     ["definitions", "1415", "Attach bump or normal maps here."]
   ]],
   ["2.2.3 Apply a cover of dust", [
-    ["definitions", "1416", "A diffuse dust cover thats more visible towards the edges of an object."],
+    ["definitions", "1416", "A diffuse dust cover thats more visible toward the edges of an object."],
     ["definitions", "1417", "Parameters:"],
     ["definitions", "1418", "name"],
     ["definitions", "1419", "type"],
@@ -577,7 +577,7 @@ var search_targets =
     ["definitions", "1535", "Attach a texturing function to define the extent of the object. Note that while the parameter is defined as \"float\", it is not meant to be used as a substitute of opacity."]
   ]],
   ["2.2.8 Add simple sticker", [
-    ["definitions", "1536", "A quick way for adding stickers to a material. The sticker is a simple dielectric and needs a mask to define it's extent"],
+    ["definitions", "1536", "A quick way for adding stickers to a material. The sticker is a simple dielectric and needs a mask to define its extent"],
     ["definitions", "1537", "Parameters:"],
     ["definitions", "1538", "name"],
     ["definitions", "1539", "type"],
@@ -668,7 +668,7 @@ var search_targets =
     ["definitions", "1618", "1000"],
     ["definitions", "1619", "the brightness of the emitted light"],
     ["definitions", "1620", "Unit for emission"],
-    ["definitions", "1621", "emmission unit type"],
+    ["definitions", "1621", "emission unit type"],
     ["definitions", "1622", "lumen&#47;m2"],
     ["definitions", "1623", "supported units are lumen&#47;m2,lumen,candela, nit (candela&#47;m2)"]
   ]],
@@ -692,7 +692,7 @@ var search_targets =
     ["definitions", "1640", "1000"],
     ["definitions", "1641", "the brightness of the emitted light"],
     ["definitions", "1642", "Unit for emission"],
-    ["definitions", "1643", "emmission unit type"],
+    ["definitions", "1643", "emission unit type"],
     ["definitions", "1644", "lumen&#47;m2"],
     ["definitions", "1645", "supported units are lumen&#47;m2,lumen,candela, nit (candela&#47;m2)"]
   ]],
@@ -732,7 +732,7 @@ var search_targets =
     ["definitions", "1676", "1000.0"],
     ["definitions", "1677", "The brightness of the light source"],
     ["definitions", "1678", "Unit for emission"],
-    ["definitions", "1679", "emmission unit type"],
+    ["definitions", "1679", "emission unit type"],
     ["definitions", "1680", "lumen&#47;m2"],
     ["definitions", "1681", "supported units are lumen&#47;m2,lumen,candela, nit (candela&#47;m2)"]
   ]],
@@ -756,7 +756,7 @@ var search_targets =
     ["definitions", "1698", "30.0"],
     ["definitions", "1699", "Larger values lead to more focused spotlights."],
     ["definitions", "1700", "Unit for emission"],
-    ["definitions", "1701", "emmission unit type"],
+    ["definitions", "1701", "emission unit type"],
     ["definitions", "1702", "lumen&#47;m2"],
     ["definitions", "1703", "supported units are lumen&#47;m2,lumen,candela, nit (candela&#47;m2)"]
   ]],
@@ -780,7 +780,7 @@ var search_targets =
     ["definitions", "1720", "1000.0"],
     ["definitions", "1721", "The brightness of the light source."]
   ]],
-  ["Texturing functions can be used to add variation to many features of a material. They can for example be used to change the color across an object, the intensities of reflections or add variations to an otherwise smooth surface through bump maps. nvidia::core_definitions suppports texturing using bitmap textures as well as a selection of procedural textures to add variation. Most texturing functions come in 2 flavours: 1 variant suitable to add bumps to a material and one variant to add color or vary roughness or reflectivity. 3.1 Bitmap texture (color/float variant)", [
+  ["Texturing functions can be used to add variation to many features of a material. They can for example be used to change the color across an object, the intensities of reflections or add variations to an otherwise smooth surface through bump maps. nvidia::core_definitions supports texturing using bitmap textures as well as a selection of procedural textures to add variation. Most texturing functions come in 2 flavors: 1 variant suitable to add bumps to a material and one variant to add color or vary roughness or reflectivity. 3.1 Bitmap texture (color/float variant)", [
     ["definitions", "1722", "This function allows texturing using image files of various file formates. It is suitable for adding variation to color or float type parameters. Parameters:"],
     ["definitions", "1723", "name"],
     ["definitions", "1724", "type"],
@@ -792,15 +792,15 @@ var search_targets =
     ["definitions", "1731", "Scalar mode"],
     ["definitions", "1732", "enum"],
     ["definitions", "1733", "\"Average\""],
-    ["definitions", "1734", "Defines what should happen if a color texture is used on a \"float\" type parameter. By defaul, the average value is used."],
+    ["definitions", "1734", "Defines what should happen if a color texture is used on a \"float\" type parameter. By default, the average value is used."],
     ["definitions", "1735", "Brightness"],
     ["definitions", "1736", "float"],
     ["definitions", "1737", "1.0"],
-    ["definitions", "1738", "A controll to vary the brightness of the image before use."],
+    ["definitions", "1738", "A control to vary the brightness of the image before use."],
     ["definitions", "1739", "Contrast"],
     ["definitions", "1740", "float"],
     ["definitions", "1741", "1.0"],
-    ["definitions", "1742", "A controll to vary the contrast of the image before use."],
+    ["definitions", "1742", "A control to vary the contrast of the image before use."],
     ["definitions", "1743", "UV space index"],
     ["definitions", "1744", "int"],
     ["definitions", "1745", "0"],
@@ -838,7 +838,7 @@ var search_targets =
     ["definitions", "1776", "Bump mode"],
     ["definitions", "1777", "enum"],
     ["definitions", "1778", "\"Average\""],
-    ["definitions", "1779", "Defines what should happen if a color texture is used on a \"float\" type parameter. By defaul, the average value is used."],
+    ["definitions", "1779", "Defines what should happen if a color texture is used on a \"float\" type parameter. By default, the average value is used."],
     ["definitions", "1780", "Bump strength"],
     ["definitions", "1781", "float"],
     ["definitions", "1782", "1.0"],
@@ -899,7 +899,7 @@ var search_targets =
     ["definitions", "1836", "Controls the scale of the texture on the object. Higher values result on higher repetition of the image."]
   ]],
   ["3.4 3d checker texture (color/float variant)", [
-    ["definitions", "1837", "Allows texturing using a 3 dimensional checkerboard pattern. 3D textures use all not just uv but uvw or object space (xyz) coordinates. If \"w\" coordinates are not explicitely provided they are set to 0. Parameters:"],
+    ["definitions", "1837", "Allows texturing using a 3 dimensional checkerboard pattern. 3D textures use all not just uv but uvw or object space (xyz) coordinates. If \"w\" coordinates are not explicitly provided they are set to 0. Parameters:"],
     ["definitions", "1838", "name"],
     ["definitions", "1839", "type"],
     ["definitions", "1840", "default"],
@@ -913,7 +913,7 @@ var search_targets =
     ["definitions", "1848", "0% black"],
     ["definitions", "1849", "2nd checker color."],
     ["definitions", "1850", "Blur"],
-    ["definitions", "1851", "floar"],
+    ["definitions", "1851", "float"],
     ["definitions", "1852", "0.0"],
     ["definitions", "1853", "Higher values lead to a blurring of the checker tiles."],
     ["definitions", "1854", "Use Object Space"],
@@ -948,7 +948,7 @@ var search_targets =
     ["definitions", "1881", "1"],
     ["definitions", "1882", "The strength of the bump mapping effect."],
     ["definitions", "1883", "Blur"],
-    ["definitions", "1884", "floar"],
+    ["definitions", "1884", "float"],
     ["definitions", "1885", "0.0"],
     ["definitions", "1886", "Higher values lead to a blurring of the checker tiles."],
     ["definitions", "1887", "Use Object Space"],
@@ -1323,7 +1323,7 @@ var search_targets =
     ["definitions", "2243", "color_layer_screen"],
     ["definitions", "2244", "1 - ((1 - B) * (1 - A))"],
     ["definitions", "2245", "color_layer_overlay"],
-    ["definitions", "2246", "For each channel individualy: if A < 0.5: B * A * 2, else: 2 * (B + A - B * A - 0.5)"],
+    ["definitions", "2246", "For each channel individually: if A < 0.5: B * A * 2, else: 2 * (B + A - B * A - 0.5)"],
     ["definitions", "2247", "color_layer_brightness"],
     ["definitions", "2248", "Hue of the A layer combined with the intensity of the B"],
     ["definitions", "2249", "color_layer_color"],
@@ -1353,9 +1353,9 @@ var search_targets =
     ["definitions", "2273", "color_layer_phoenix"],
     ["definitions", "2274", "Minimum of both layers minus the maximum of both layers (plus 1.0)"],
     ["definitions", "2275", "color_layer_hardlight"],
-    ["definitions", "2276", "For each channel individualy: if B > 0.5: B * A * 2, else: 2 * (B + A - B * A - 0.5)"],
+    ["definitions", "2276", "For each channel individually: if B > 0.5: B * A * 2, else: 2 * (B + A - B * A - 0.5)"],
     ["definitions", "2277", "color_layer_hardmix"],
-    ["definitions", "2278", "For each channel individualy: (B + A < = 1) ? 0 : 1"],
+    ["definitions", "2278", "For each channel individually: (B + A < = 1) ? 0 : 1"],
     ["definitions", "2279", "color_layer_lineardodge"],
     ["definitions", "2280", "B + A (clamped)"],
     ["definitions", "2281", "color_layer_linearburn"],
@@ -1404,7 +1404,7 @@ var section_headers = {
   "2.3.2 Spotlight emission": ["definitions", "spotlight-emission"],
   "2.3.3 IES file based emission": ["definitions", "ies-file-based-emission"],
   "3 Texturing functions": ["definitions", "texturing-functions"],
-  "Texturing functions can be used to add variation to many features of a material. They can for example be used to change the color across an object, the intensities of reflections or add variations to an otherwise smooth surface through bump maps. nvidia::core_definitions suppports texturing using bitmap textures as well as a selection of procedural textures to add variation. Most texturing functions come in 2 flavours: 1 variant suitable to add bumps to a material and one variant to add color or vary roughness or reflectivity. 3.1 Bitmap texture (color/float variant)": ["definitions", "bitmap-texture-color-float-variant-"],
+  "Texturing functions can be used to add variation to many features of a material. They can for example be used to change the color across an object, the intensities of reflections or add variations to an otherwise smooth surface through bump maps. nvidia::core_definitions supports texturing using bitmap textures as well as a selection of procedural textures to add variation. Most texturing functions come in 2 flavors: 1 variant suitable to add bumps to a material and one variant to add color or vary roughness or reflectivity. 3.1 Bitmap texture (color/float variant)": ["definitions", "bitmap-texture-color-float-variant-"],
   "3.2 Bitmap texture (bump variant)": ["definitions", "bitmap-texture-bump-variant-"],
   "3.3 Normalmap texture": ["definitions", "normalmap-texture"],
   "3.4 3d checker texture (color/float variant)": ["definitions", "3d-checker-texture-color-float-variant-"],

--- a/doc/core_definitions/pages/definitions.html
+++ b/doc/core_definitions/pages/definitions.html
@@ -14,7 +14,7 @@
 <p id="1001">The Material Definition Language (MDL) module <span class="monospace">nvidia::core_definitions</span>
 contains a collection of MDL materials that can either be used independently (<i>simple materials</i>) or in combination with other materials through the use of <i>material combiners</i> and <i>material modifiers</i>. <i>Texturing functions</i>
 provide further control and refinement of material parameter values.  Together,
-materials, combiners, modfiers and the texturing functions can simulate complex,
+materials, combiners, modifiers and the texturing functions can simulate complex,
 real-world models of appearance.</p>
 
 
@@ -486,7 +486,7 @@ have an index of refraction of around 1.5. Realistic values are between 1.0 and 
 <td id="1257" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">Metallic material</td>
 <td id="1258" class="tfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">bool</td>
 <td id="1259" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">false</td>
-<td id="1260" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">If true, reflection will be colored and independent of view direction. If false, reflection will be white and direction dependent. Directional dependence is in this case based on the index of refraction (Fresnell effect).</td>
+<td id="1260" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">If true, reflection will be colored and independent of view direction. If false, reflection will be white and direction dependent. Directional dependence is in this case based on the index of refraction (Fresnel effect).</td>
 </tr>
 <tr>
 <td id="1261" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">Reflection weight</td>
@@ -540,7 +540,7 @@ have an index of refraction of around 1.5. Realistic values are between 1.0 and 
 <td id="1293" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">Transmission weight</td>
 <td id="1294" class="tfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">float</td>
 <td id="1295" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">0.0</td>
-<td id="1296" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">Weights how much light passes through the object vs it's diffuse reflectivity  Values must be between 0.0 and 1.0.</td>
+<td id="1296" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">Weights how much light passes through the object vs its diffuse reflectivity  Values must be between 0.0 and 1.0.</td>
 </tr>
 <tr>
 <td id="1297" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">IOR</td>
@@ -629,7 +629,7 @@ have an index of refraction of around 1.5. Realistic values are between 1.0 and 
 <td id="1347" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">IOR</td>
 <td id="1348" class="tfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">float</td>
 <td id="1349" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">1.6</td>
-<td id="1350" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">termines reflectivity of the clear coat. Realistic values are between 1.0 and 4.0.</td>
+<td id="1350" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">determines reflectivity of the clear coat. Realistic values are between 1.0 and 4.0.</td>
 </tr>
 <tr>
 <td id="1351" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">Coat roughness</td>
@@ -741,7 +741,7 @@ have an index of refraction of around 1.5. Realistic values are between 1.0 and 
 <td id="1408" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">Reflection weight</td>
 <td id="1409" class="tfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">float</td>
 <td id="1410" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">0.3</td>
-<td id="1411" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">The oacity of the metallic coat.  Values must be between 0.0 and 1.0.</td>
+<td id="1411" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">The opacity of the metallic coat.  Values must be between 0.0 and 1.0.</td>
 </tr>
 <tr style=" border-bottom: solid 1px black;">
 <td id="1412" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">Bumps</td>
@@ -755,7 +755,7 @@ have an index of refraction of around 1.5. Realistic values are between 1.0 and 
 <h3 id="apply-a-cover-of-dust" class="headerlink"><span class="sectionnumber">2.2.3</span>Apply a cover of dust</h3>
 
 
-<p id="1416">A diffuse dust cover thats more visible towards the edges of an object.</p>
+<p id="1416">A diffuse dust cover thats more visible toward the edges of an object.</p>
 
 <p id="1417">Parameters:</p>
 
@@ -976,7 +976,7 @@ Parameters:</p>
 <h3 id="add-simple-sticker" class="headerlink"><span class="sectionnumber">2.2.8</span>Add simple sticker</h3>
 
 
-<p id="1536">A quick way for adding stickers to a material. The sticker is a simple dielectric and needs a mask to define it's extent</p>
+<p id="1536">A quick way for adding stickers to a material. The sticker is a simple dielectric and needs a mask to define its extent</p>
 
 <p id="1537">Parameters:</p>
 
@@ -1130,7 +1130,7 @@ Parameters:</p>
 </tr>
 <tr style=" border-bottom: solid 1px black;">
 <td id="1620" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">Unit for emission</td>
-<td id="1621" class="tfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">emmission unit type</td>
+<td id="1621" class="tfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">emission unit type</td>
 <td id="1622" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">lumen/m2</td>
 <td id="1623" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">supported units are lumen/m2,lumen,candela, nit (candela/m2)</td>
 </tr>
@@ -1171,7 +1171,7 @@ Parameters:</p>
 </tr>
 <tr style=" border-bottom: solid 1px black;">
 <td id="1642" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">Unit for emission</td>
-<td id="1643" class="tfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">emmission unit type</td>
+<td id="1643" class="tfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">emission unit type</td>
 <td id="1644" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">lumen/m2</td>
 <td id="1645" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">supported units are lumen/m2,lumen,candela, nit (candela/m2)</td>
 </tr>
@@ -1246,7 +1246,7 @@ In MDL, there is no distinction between regular objects and lightsources. Any ob
 </tr>
 <tr style=" border-bottom: solid 1px black;">
 <td id="1678" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">Unit for emission</td>
-<td id="1679" class="tfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">emmission unit type</td>
+<td id="1679" class="tfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">emission unit type</td>
 <td id="1680" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">lumen/m2</td>
 <td id="1681" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">supported units are lumen/m2,lumen,candela, nit (candela/m2)</td>
 </tr>
@@ -1287,7 +1287,7 @@ In MDL, there is no distinction between regular objects and lightsources. Any ob
 </tr>
 <tr style=" border-bottom: solid 1px black;">
 <td id="1700" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">Unit for emission</td>
-<td id="1701" class="tfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">emmission unit type</td>
+<td id="1701" class="tfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">emission unit type</td>
 <td id="1702" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">lumen/m2</td>
 <td id="1703" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">supported units are lumen/m2,lumen,candela, nit (candela/m2)</td>
 </tr>
@@ -1332,7 +1332,7 @@ In MDL, there is no distinction between regular objects and lightsources. Any ob
 <h1 id="texturing-functions" style="clear:both;" class="headerlink"><span class="sectionnumber">3</span>Texturing functions</h1>
 
 Texturing functions can be used to add variation to many features of a material. They can for example be used to change the color across an object, the intensities of reflections or add variations to an otherwise smooth surface through bump maps.
-nvidia::core_definitions suppports texturing using bitmap textures as well as a selection of procedural textures to add variation. Most texturing functions come in 2 flavours: 1 variant suitable to add bumps to a material and one variant to add color or vary roughness or reflectivity.
+nvidia::core_definitions supports texturing using bitmap textures as well as a selection of procedural textures to add variation. Most texturing functions come in 2 flavors: 1 variant suitable to add bumps to a material and one variant to add color or vary roughness or reflectivity.
 
 
 <h2 id="bitmap-texture-color-float-variant-" class="headerlink"><span class="sectionnumber">3.1</span>Bitmap texture (color/float variant)</h2>
@@ -1358,19 +1358,19 @@ This function allows texturing using image files of various file formates. It is
 <td id="1731" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">Scalar mode</td>
 <td id="1732" class="tfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">enum</td>
 <td id="1733" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">"Average"</td>
-<td id="1734" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">Defines what should happen if a color texture is used on a "float" type parameter. By defaul, the average value is used.</td>
+<td id="1734" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">Defines what should happen if a color texture is used on a "float" type parameter. By default, the average value is used.</td>
 </tr>
 <tr>
 <td id="1735" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">Brightness</td>
 <td id="1736" class="tfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">float</td>
 <td id="1737" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">1.0</td>
-<td id="1738" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">A controll to vary the brightness of the image before use.</td>
+<td id="1738" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">A control to vary the brightness of the image before use.</td>
 </tr>
 <tr>
 <td id="1739" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">Contrast</td>
 <td id="1740" class="tfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">float</td>
 <td id="1741" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">1.0</td>
-<td id="1742" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">A controll to vary the contrast of the image before use.</td>
+<td id="1742" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">A control to vary the contrast of the image before use.</td>
 </tr>
 <tr>
 <td id="1743" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">UV space index</td>
@@ -1434,7 +1434,7 @@ Allows texturing using image files of various file formates. The image is interp
 <td id="1776" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">Bump mode</td>
 <td id="1777" class="tfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">enum</td>
 <td id="1778" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">"Average"</td>
-<td id="1779" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">Defines what should happen if a color texture is used on a "float" type parameter. By defaul, the average value is used.</td>
+<td id="1779" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">Defines what should happen if a color texture is used on a "float" type parameter. By default, the average value is used.</td>
 </tr>
 <tr>
 <td id="1780" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">Bump strength</td>
@@ -1535,7 +1535,7 @@ Allows the use of tangent space normal maps.
 
 <h2 id="3d-checker-texture-color-float-variant-" class="headerlink"><span class="sectionnumber">3.4</span>3d checker texture (color/float variant)</h2>
 
-Allows texturing using a 3 dimensional checkerboard pattern. 3D textures use all not just uv but uvw or object space (xyz) coordinates. If "w" coordinates are not explicitely provided they are set to 0.
+Allows texturing using a 3 dimensional checkerboard pattern. 3D textures use all not just uv but uvw or object space (xyz) coordinates. If "w" coordinates are not explicitly provided they are set to 0.
 
 <p id="1837">Parameters:</p>
 
@@ -1560,7 +1560,7 @@ Allows texturing using a 3 dimensional checkerboard pattern. 3D textures use all
 </tr>
 <tr>
 <td id="1850" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">Blur</td>
-<td id="1851" class="tfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">floar</td>
+<td id="1851" class="tfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">float</td>
 <td id="1852" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">0.0</td>
 <td id="1853" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">Higher values lead to a blurring of the checker tiles.</td>
 </tr>
@@ -1618,7 +1618,7 @@ Allows texturing using a checkerboard pattern.
 </tr>
 <tr>
 <td id="1883" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">Blur</td>
-<td id="1884" class="tfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">floar</td>
+<td id="1884" class="tfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">float</td>
 <td id="1885" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">0.0</td>
 <td id="1886" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">Higher values lead to a blurring of the checker tiles.</td>
 </tr>
@@ -2232,7 +2232,7 @@ short description of the matching blend function.</p>
 </tr>
 <tr>
 <td id="2245" class="tfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">color_layer_overlay</td>
-<td id="2246" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px; width:57.96vw">For each channel individualy: if A < 0.5: B * A * 2, else: 2 * (B + A - B * A - 0.5)</td>
+<td id="2246" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px; width:57.96vw">For each channel individually: if A < 0.5: B * A * 2, else: 2 * (B + A - B * A - 0.5)</td>
 </tr>
 <tr>
 <td id="2247" class="tfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">color_layer_brightness</td>
@@ -2293,12 +2293,12 @@ short description of the matching blend function.</p>
 </tr>
 <tr>
 <td id="2275" class="tfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">color_layer_hardlight</td>
-<td id="2276" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px; width:57.96vw">For each channel individualy: if B > 0.5:
+<td id="2276" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px; width:57.96vw">For each channel individually: if B > 0.5:
   B * A * 2, else: 2 * (B + A - B * A - 0.5)</td>
 </tr>
 <tr>
 <td id="2277" class="tfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">color_layer_hardmix</td>
-<td id="2278" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px; width:57.96vw">For each channel individualy: (B + A <= 1) ? 0 : 1</td>
+<td id="2278" class="rfont lhpos tvpos tline rline bline lline" style="padding:3px 6px; width:57.96vw">For each channel individually: (B + A <= 1) ? 0 : 1</td>
 </tr>
 <tr>
 <td id="2279" class="tfont lhpos tvpos tline rline bline lline" style="padding:3px 6px;">color_layer_lineardodge</td>

--- a/doc/index.html
+++ b/doc/index.html
@@ -54,7 +54,7 @@
 	    API documentation</a>  for an overview.
 	</p>
 	<p>
-	  <b>Note:</b> You need to build the API documention before you can browse
+	  <b>Note:</b> You need to build the API documentation before you can browse
 	  it from the links above.
 	</p>
       </div>

--- a/doc/mathapi/version.dox
+++ b/doc/mathapi/version.dox
@@ -36,7 +36,7 @@ compatibility between different versions.
 
 \section mi_math_version_api API Version of a Shared Library
 
-<b>This section does currently not apply. It will be reviewed towards
+<b>This section does currently not apply. It will be reviewed toward
 the end of the Math API development</b>
 
 Assuming the API is provided in the form of a shared library (also

--- a/doc/mdl_coreapi/Doxyfile
+++ b/doc/mdl_coreapi/Doxyfile
@@ -1243,7 +1243,7 @@ SEARCHENGINE           = YES
 
 # When the SERVER_BASED_SEARCH tag is enabled the search engine will be
 # implemented using a web server instead of a web client using Javascript.
-# There are two flavours of web server based search depending on the
+# There are two flavors of web server based search depending on the
 # EXTERNAL_SEARCH setting. When disabled, doxygen will generate a PHP script for
 # searching and an index file used by the script. When EXTERNAL_SEARCH is
 # enabled the indexing and searching needs to be provided by external tools.

--- a/doc/mdl_sdkapi/Doxyfile
+++ b/doc/mdl_sdkapi/Doxyfile
@@ -1260,7 +1260,7 @@ SEARCHENGINE           = YES
 
 # When the SERVER_BASED_SEARCH tag is enabled the search engine will be
 # implemented using a web server instead of a web client using Javascript.
-# There are two flavours of web server based search depending on the
+# There are two flavors of web server based search depending on the
 # EXTERNAL_SEARCH setting. When disabled, doxygen will generate a PHP script for
 # searching and an index file used by the script. When EXTERNAL_SEARCH is
 # enabled the indexing and searching needs to be provided by external tools.

--- a/examples/mdl/nvidia/sdk_examples/gltf_support.mdl
+++ b/examples/mdl/nvidia/sdk_examples/gltf_support.mdl
@@ -184,7 +184,7 @@ export material gltf_material(
         );
 
     // the metallic component doesn't have a diffuse component, 
-    // it's only glossy base_color is applied to tint it
+    // its only glossy base_color is applied to tint it
     bsdf metallic_component = df::microfacet_ggx_vcavities_bsdf(
         tint: base_color * occlusion, 
         roughness_u: roughness2);

--- a/examples/mdl_sdk/mdl_browser/mdl_qt_plugin/include/mdl_qt_plugin.h
+++ b/examples/mdl_sdk/mdl_browser/mdl_qt_plugin/include/mdl_qt_plugin.h
@@ -161,7 +161,7 @@ public:
     // meant to be used for non-Qt-based applications.
     virtual void show_select_material_dialog(Mdl_qt_plugin_context* context, Mdl_qt_plguin_browser_handle& out_handle) = 0;
 
-    // to be called from the application to unload the plugin and free it's resources.
+    // to be called from the application to unload the plugin and free its resources.
     virtual void unload() = 0;
 
 protected:

--- a/examples/thirdparty/d3dx12/d3dx12.h
+++ b/examples/thirdparty/d3dx12/d3dx12.h
@@ -2709,10 +2709,10 @@ inline bool operator==( const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC &a, const D3D
 // Helper classes for creating new style state objects out of an arbitrary set of subobjects.
 // Uses STL
 //
-// Start by instantiating CD3DX12_STATE_OBJECT_DESC (see it's public methods).
+// Start by instantiating CD3DX12_STATE_OBJECT_DESC (see its public methods).
 // One of its methods is CreateSubobject(), which has a comment showing a couple of options for
 // defining subobjects using the helper classes for each subobject (CD3DX12_DXIL_LIBRARY_SUBOBJECT 
-// etc.). The subobject helpers each have methods specific to the subobject for configuring it's 
+// etc.). The subobject helpers each have methods specific to the subobject for configuring its 
 // contents.
 // 
 //================================================================================================
@@ -2742,7 +2742,7 @@ public:
         m_SubobjectArray.clear();
         m_SubobjectArray.reserve(m_Desc.NumSubobjects);
         // Flatten subobjects into an array (each flattened subobject still has a 
-        // member that's a pointer to it's desc that's not flattened)
+        // member that's a pointer to its desc that's not flattened)
         for (auto Iter = m_SubobjectList.begin();
             Iter != m_SubobjectList.end(); Iter++)
         {
@@ -2791,7 +2791,7 @@ public:
     // variables instead, passing the state object desc that should point to it into the helper 
     // constructor (or call mySubobjectHelper.AddToStateObject(Collection1)).  
     // In this alternative scenario, the user must keep the subobject alive as long as the state 
-    // object it is associated with is alive, else it's pointer references will be stale.
+    // object it is associated with is alive, else its pointer references will be stale.
     // e.g.
     //
     //    CD3DX12_STATE_OBJECT_DESC RaytracingState2(D3D12_STATE_OBJECT_TYPE_RAYTRACING_PIPELINE);

--- a/examples/thirdparty/gltf/nlohmann/json.hpp
+++ b/examples/thirdparty/gltf/nlohmann/json.hpp
@@ -7526,7 +7526,7 @@ namespace detail
 @brief an iterator for primitive JSON types
 
 This class models an iterator for primitive JSON types (boolean, number,
-string). It's only purpose is to allow the iterator/const_iterator classes
+string). Its only purpose is to allow the iterator/const_iterator classes
 to "iterate" over primitive values. Internally, the iterator is modeled by
 a `difference_type` variable. Value begin_value (`0`) models the begin,
 end_value (`1`) models past the end.

--- a/examples/thirdparty/tinyxml2/src/tinyxml2.cpp
+++ b/examples/thirdparty/tinyxml2/src/tinyxml2.cpp
@@ -915,7 +915,7 @@ XMLNode* XMLNode::InsertAfterChild( XMLNode* afterThis, XMLNode* addThis )
     }
     if ( afterThis == addThis ) {
         // Current state: BeforeThis -> AddThis -> OneAfterAddThis
-        // Now AddThis must disappear from it's location and then
+        // Now AddThis must disappear from its location and then
         // reappear between BeforeThis and OneAfterAddThis.
         // So just leave it where it is.
         return addThis;

--- a/src/base/data/serial/i_serializer.h
+++ b/src/base/data/serial/i_serializer.h
@@ -287,7 +287,7 @@ public:
     ///
     /// \param marker_status    Type of error encountered.
     /// \param serializable     Pointer to serializable object that failed deserializing.
-    ///                         Only it's class id is known to be defined.
+    ///                         Only its class id is known to be defined.
     virtual void handle(Marker_status status, const T* serializable) = 0;
 };
 

--- a/src/base/lib/tinyxml2/tinyxml2.cpp
+++ b/src/base/lib/tinyxml2/tinyxml2.cpp
@@ -915,7 +915,7 @@ XMLNode* XMLNode::InsertAfterChild( XMLNode* afterThis, XMLNode* addThis )
     }
     if ( afterThis == addThis ) {
         // Current state: BeforeThis -> AddThis -> OneAfterAddThis
-        // Now AddThis must disappear from it's location and then
+        // Now AddThis must disappear from its location and then
         // reappear between BeforeThis and OneAfterAddThis.
         // So just leave it where it is.
         return addThis;

--- a/src/mdl/jit/llvm/dist/include/llvm/Analysis/BlockFrequencyInfoImpl.h
+++ b/src/mdl/jit/llvm/dist/include/llvm/Analysis/BlockFrequencyInfoImpl.h
@@ -183,7 +183,7 @@ public:
   /// traversal of the blocks.
   ///
   /// Unlike a block pointer, its order has meaning (location in the
-  /// topological sort) and it's class is the same regardless of block type.
+  /// topological sort) and its class is the same regardless of block type.
   struct BlockNode {
     using IndexType = uint32_t;
 

--- a/src/mdl/jit/llvm/dist/include/llvm/Support/CommandLine.h
+++ b/src/mdl/jit/llvm/dist/include/llvm/Support/CommandLine.h
@@ -684,7 +684,7 @@ public:
                               const GenericOptionValue &Default,
                               size_t GlobalWidth) const;
 
-  // printOptionDiff - print the value of an option and it's default.
+  // printOptionDiff - print the value of an option and its default.
   //
   // Template definition ensures that the option and default have the same
   // DataType (via the same AnyOptionValue).

--- a/src/mdl/jit/llvm/dist/lib/CodeGen/MachineLICM.cpp
+++ b/src/mdl/jit/llvm/dist/lib/CodeGen/MachineLICM.cpp
@@ -941,7 +941,7 @@ static bool isInvariantStore(const MachineInstr &MI,
 
 // Return true if the input MI is a copy instruction that feeds an invariant
 // store instruction. This means that the src of the copy has to satisfy
-// isCallerPreservedPhysReg and atleast one of it's users should satisfy
+// isCallerPreservedPhysReg and atleast one of its users should satisfy
 // isInvariantStore.
 static bool isCopyFeedingInvariantStore(const MachineInstr &MI,
                                         const MachineRegisterInfo *MRI,

--- a/src/mdl/jit/llvm/dist/lib/CodeGen/SelectionDAG/StatepointLowering.h
+++ b/src/mdl/jit/llvm/dist/lib/CodeGen/SelectionDAG/StatepointLowering.h
@@ -103,7 +103,7 @@ public:
 
 private:
   /// Maps pre-relocation value (gc pointer directly incoming into statepoint)
-  /// into it's location (currently only stack slots)
+  /// into its location (currently only stack slots)
   DenseMap<SDValue, SDValue> Locations;
 
   /// A boolean indicator for each slot listed in the FunctionInfo as to

--- a/src/mdl/jit/llvm/dist/lib/CodeGen/TargetInstrInfo.cpp
+++ b/src/mdl/jit/llvm/dist/lib/CodeGen/TargetInstrInfo.cpp
@@ -1083,7 +1083,7 @@ unsigned TargetInstrInfo::getNumMicroOps(const InstrItineraryData *ItinData,
   return 1;
 }
 
-/// Return the default expected latency for a def based on it's opcode.
+/// Return the default expected latency for a def based on its opcode.
 unsigned TargetInstrInfo::defaultDefLatency(const MCSchedModel &SchedModel,
                                             const MachineInstr &DefMI) const {
   if (DefMI.isTransient())

--- a/src/mdl/jit/llvm/dist/lib/IR/AsmWriter.cpp
+++ b/src/mdl/jit/llvm/dist/lib/IR/AsmWriter.cpp
@@ -727,7 +727,7 @@ public:
   SlotTracker(const SlotTracker &) = delete;
   SlotTracker &operator=(const SlotTracker &) = delete;
 
-  /// Return the slot number of the specified value in it's type
+  /// Return the slot number of the specified value in its type
   /// plane.  If something is not in the SlotTracker, return -1.
   int getLocalSlot(const Value *V);
   int getGlobalSlot(const GlobalValue *V);

--- a/src/mdl/jit/llvm/dist/lib/Object/MachOUniversal.cpp
+++ b/src/mdl/jit/llvm/dist/lib/Object/MachOUniversal.cpp
@@ -168,7 +168,7 @@ MachOUniversalBinary::MachOUniversalBinary(MemoryBufferRef Source, Error &Err)
       Err = malformedError("offset: " + Twine(A.getOffset()) +
         " for cputype (" + Twine(A.getCPUType()) + ") cpusubtype (" +
         Twine(A.getCPUSubType() & ~MachO::CPU_SUBTYPE_MASK) +
-        ") not aligned on it's alignment (2^" + Twine(A.getAlign()) + ")");
+        ") not aligned on its alignment (2^" + Twine(A.getAlign()) + ")");
       return;
     }
     if (A.getOffset() < MinSize) {

--- a/src/mdl/jit/llvm/dist/lib/Support/CommandLine.cpp
+++ b/src/mdl/jit/llvm/dist/lib/Support/CommandLine.cpp
@@ -1662,7 +1662,7 @@ void generic_parser_base::printOptionInfo(const Option &O,
 
 static const size_t MaxOptWidth = 8; // arbitrary spacing for printOptionDiff
 
-// printGenericOptionDiff - Print the value of this option and it's default.
+// printGenericOptionDiff - Print the value of this option and its default.
 //
 // "Generic" options have each value mapped to a name.
 void generic_parser_base::printGenericOptionDiff(

--- a/src/mdl/jit/llvm/dist/lib/Transforms/IPO/GlobalOpt.cpp
+++ b/src/mdl/jit/llvm/dist/lib/Transforms/IPO/GlobalOpt.cpp
@@ -423,7 +423,7 @@ static bool GlobalUsersSafeToSRA(GlobalValue *GV) {
         cast<ConstantExpr>(U)->getOpcode() != Instruction::GetElementPtr))
       return false;
 
-    // Check the gep and it's users are safe to SRA
+    // Check the gep and its users are safe to SRA
     if (!isSafeSROAGEP(U))
       return false;
   }

--- a/src/mdl/jit/llvm/dist/lib/Transforms/Scalar/IndVarSimplify.cpp
+++ b/src/mdl/jit/llvm/dist/lib/Transforms/Scalar/IndVarSimplify.cpp
@@ -1274,7 +1274,7 @@ WidenIV::WidenedRecTy WidenIV::getExtendedOperandRecurrence(NarrowIVDefUse DU) {
 }
 
 /// Is this instruction potentially interesting for further simplification after
-/// widening it's type? In other words, can the extend be safely hoisted out of
+/// widening its type? In other words, can the extend be safely hoisted out of
 /// the loop with SCEV reducing the value to a recurrence on the same loop. If
 /// so, return the extended recurrence and the kind of extension used. Otherwise
 /// return {nullptr, Unknown}.

--- a/src/mdl/jit/llvm/dist/lib/Transforms/Scalar/LICM.cpp
+++ b/src/mdl/jit/llvm/dist/lib/Transforms/Scalar/LICM.cpp
@@ -769,7 +769,7 @@ CloneInstructionInExitBlock(Instruction &I, BasicBlock &ExitBlock, PHINode &PN,
 
     // Sinking call-sites need to be handled differently from other
     // instructions.  The cloned call-site needs a funclet bundle operand
-    // appropriate for it's location in the CFG.
+    // appropriate for its location in the CFG.
     SmallVector<OperandBundleDef, 1> OpBundles;
     for (unsigned BundleIdx = 0, BundleEnd = CI->getNumOperandBundles();
          BundleIdx != BundleEnd; ++BundleIdx) {

--- a/src/mdl/jit/llvm/dist/lib/Transforms/Vectorize/LoopVectorize.cpp
+++ b/src/mdl/jit/llvm/dist/lib/Transforms/Vectorize/LoopVectorize.cpp
@@ -4391,7 +4391,7 @@ bool LoopVectorizationCostModel::memoryInstructionCanBeWidened(Instruction *I,
   if (isScalarWithPredication(I))
     return false;
 
-  // If the instruction's allocated size doesn't equal it's type size, it
+  // If the instruction's allocated size doesn't equal its type size, it
   // requires padding and will be scalarized.
   auto &DL = I->getModule()->getDataLayout();
   auto *ScalarTy = LI ? LI->getType() : SI->getValueOperand()->getType();

--- a/src/mdl/jit/llvm/dist/tools/llvm-objdump/MachODump.cpp
+++ b/src/mdl/jit/llvm/dist/tools/llvm-objdump/MachODump.cpp
@@ -1833,7 +1833,7 @@ static void printMachOUniversalHeaders(const object::MachOUniversalBinary *UB,
     if (OFA.getOffset() > size)
       outs() << " (past end of file)";
     if (OFA.getOffset() % (1 << OFA.getAlign()) != 0)
-      outs() << " (not aligned on it's alignment (2^" << OFA.getAlign() << ")";
+      outs() << " (not aligned on its alignment (2^" << OFA.getAlign() << ")";
     outs() << "\n";
     outs() << "    size " << OFA.getSize();
     big_size = OFA.getOffset() + OFA.getSize();

--- a/src/mdl/jit/llvm/dist/tools/opt/NewPMDriver.h
+++ b/src/mdl/jit/llvm/dist/tools/opt/NewPMDriver.h
@@ -46,7 +46,7 @@ enum VerifierKind {
 ///
 /// This function only exists factored away from opt.cpp in order to prevent
 /// inclusion of the new pass manager headers and the old headers into the same
-/// file. It's interface is consequentially somewhat ad-hoc, but will go away
+/// file. Its interface is consequentially somewhat ad-hoc, but will go away
 /// when the transition finishes.
 ///
 /// ThinLTOLinkOut is only used when OK is OK_OutputThinLTOBitcode, and can be

--- a/src/mdl/jit/llvm/dist/unittests/Analysis/ScalarEvolutionTest.cpp
+++ b/src/mdl/jit/llvm/dist/unittests/Analysis/ScalarEvolutionTest.cpp
@@ -735,7 +735,7 @@ TEST_F(ScalarEvolutionsTest, SCEVZeroExtendExprNonIntegral) {
    * then check that no inttoptr/ptrtoint instructions got inserted.
    */
 
-  // Create a module with non-integral pointers in it's datalayout
+  // Create a module with non-integral pointers in its data layout
   Module NIM("nonintegral", Context);
   std::string DataLayout = M.getDataLayoutStr();
   if (!DataLayout.empty())
@@ -809,7 +809,7 @@ TEST_F(ScalarEvolutionsTest, SCEVExitLimitForgetLoop) {
    *
    */
 
-  // Create a module with non-integral pointers in it's datalayout
+  // Create a module with non-integral pointers in its data layout
   Module NIM("nonintegral", Context);
   std::string DataLayout = M.getDataLayoutStr();
   if (!DataLayout.empty())
@@ -907,7 +907,7 @@ TEST_F(ScalarEvolutionsTest, SCEVExitLimitForgetValue) {
    *
    */
 
-  // Create a module with non-integral pointers in it's datalayout
+  // Create a module with non-integral pointers in its data layout
   Module NIM("nonintegral", Context);
   std::string DataLayout = M.getDataLayoutStr();
   if (!DataLayout.empty())
@@ -1133,7 +1133,7 @@ TEST_F(ScalarEvolutionsTest, SCEVExpanderIsSafeToExpandAt) {
    *
    */
 
-  // Create a module with non-integral pointers in it's datalayout
+  // Create a module with non-integral pointers in its data layout
   Module NIM("nonintegral", Context);
   std::string DataLayout = M.getDataLayoutStr();
   if (!DataLayout.empty())

--- a/src/mdl/jit/llvm/dist/unittests/Analysis/SparsePropagation.cpp
+++ b/src/mdl/jit/llvm/dist/unittests/Analysis/SparsePropagation.cpp
@@ -53,7 +53,7 @@ public:
   /// interesting; the rest are special states used by the generic solver. The
   /// UntrackedVal state differs from the other three in that the generic
   /// solver uses it to avoid doing unnecessary work. In particular, when a
-  /// value moves to the UntrackedVal state, it's users are not notified.
+  /// value moves to the UntrackedVal state, its users are not notified.
   enum TestLatticeStateTy {
     UndefinedVal,
     ConstantVal,

--- a/src/mdl/jit/llvm/dist/unittests/FuzzMutate/RandomIRBuilderTest.cpp
+++ b/src/mdl/jit/llvm/dist/unittests/FuzzMutate/RandomIRBuilderTest.cpp
@@ -119,7 +119,7 @@ TEST(RandomIRBuilderTest, InsertValueIndexes) {
   for (auto *T: Types) {
     // Loop to account for possible random decisions
     for (int i = 0; i < 10; ++i) {
-      // Create value we want to insert. Only it's type matters.
+      // Create value we want to insert. Only its type matters.
       Srcs[1] = ConstantInt::get(T, 5);
 
       // Try to pick correct index

--- a/src/mdl/jit/llvm/dist/utils/TableGen/AsmMatcherEmitter.cpp
+++ b/src/mdl/jit/llvm/dist/utils/TableGen/AsmMatcherEmitter.cpp
@@ -348,7 +348,7 @@ public:
       }
     } else if (isRegisterClass()) {
       // For register sets, sort by number of registers. This guarantees that
-      // a set will always sort before all of it's strict supersets.
+      // a set will always sort before all of its strict supersets.
       if (Registers.size() != RHS.Registers.size())
         return Registers.size() < RHS.Registers.size();
     } else {

--- a/src/mdl/jit/llvm/dist/utils/TableGen/CodeGenDAGPatterns.cpp
+++ b/src/mdl/jit/llvm/dist/utils/TableGen/CodeGenDAGPatterns.cpp
@@ -2388,7 +2388,7 @@ bool TreePatternNode::ApplyTypeConstraints(TreePattern &TP, bool NotRegisters) {
       Record *OperandNode = Inst.getOperand(i);
 
       // If the instruction expects a predicate or optional def operand, we
-      // codegen this by setting the operand to it's default value if it has a
+      // codegen this by setting the operand to its default value if it has a
       // non-empty DefaultOps field.
       if (OperandNode->isSubClassOf("OperandWithDefaultOps") &&
           !CDP.getDefaultOperand(OperandNode).DefaultOps.empty())

--- a/src/mdl/jit/llvm/dist/utils/TableGen/CodeGenSchedule.cpp
+++ b/src/mdl/jit/llvm/dist/utils/TableGen/CodeGenSchedule.cpp
@@ -844,7 +844,7 @@ void CodeGenSchedModels::createInstRWClass(Record *InstRWDef) {
     SC.Writes = SchedClasses[OldSCIdx].Writes;
     SC.Reads = SchedClasses[OldSCIdx].Reads;
     SC.ProcIndices.push_back(0);
-    // If we had an old class, copy it's InstRWs to this new class.
+    // If we had an old class, copy its InstRWs to this new class.
     if (OldSCIdx) {
       Record *RWModelDef = InstRWDef->getValueAsDef("SchedModel");
       for (Record *OldRWDef : SchedClasses[OldSCIdx].InstRWs) {

--- a/src/mdl/jit/llvm/dist/utils/TableGen/CodeGenSchedule.h
+++ b/src/mdl/jit/llvm/dist/utils/TableGen/CodeGenSchedule.h
@@ -299,7 +299,7 @@ class CodeGenSchedModels {
   RecVec ProcResGroups;
 
   // Map each instruction to its unique SchedClass index considering the
-  // combination of it's itinerary class, SchedRW list, and InstRW records.
+  // combination of its itinerary class, SchedRW list, and InstRW records.
   using InstClassMapTy = DenseMap<Record*, unsigned>;
   InstClassMapTy InstrClassMap;
 

--- a/src/mdl/jit/llvm/dist/utils/TableGen/DAGISelMatcherGen.cpp
+++ b/src/mdl/jit/llvm/dist/utils/TableGen/DAGISelMatcherGen.cpp
@@ -310,7 +310,7 @@ void MatcherGen::EmitOperatorMatchCode(const TreePatternNode *N,
   // If this is an 'and R, 1234' where the operation is AND/OR and the RHS is
   // a constant without a predicate fn that has more than one bit set, handle
   // this as a special case.  This is usually for targets that have special
-  // handling of certain large constants (e.g. alpha with it's 8/16/32-bit
+  // handling of certain large constants (e.g. alpha with its 8/16/32-bit
   // handling stuff).  Using these instructions is often far more efficient
   // than materializing the constant.  Unfortunately, both the instcombiner
   // and the dag combiner can often infer that bits are dead, and thus drop

--- a/src/mdl/jit/llvm/dist/utils/TableGen/GlobalISelEmitter.cpp
+++ b/src/mdl/jit/llvm/dist/utils/TableGen/GlobalISelEmitter.cpp
@@ -3944,7 +3944,7 @@ Expected<RuleMatcher> GlobalISelEmitter::runOnPattern(const PatternToMatch &P) {
       if (!Dst->getChild(0)->isLeaf())
         return failedImport("EXTRACT_SUBREG operand #0 isn't a leaf");
 
-      // We can assume that a subregister is in the same bank as it's super
+      // We can assume that a subregister is in the same bank as its super
       // register.
       DstIOpRec = getInitValueAsRegClass(Dst->getChild(0)->getLeafValue());
 

--- a/src/mdl/jit/llvm/dist/utils/TableGen/X86EVEX2VEXTablesEmitter.cpp
+++ b/src/mdl/jit/llvm/dist/utils/TableGen/X86EVEX2VEXTablesEmitter.cpp
@@ -197,7 +197,7 @@ void X86EVEX2VEXTablesEmitter::run(raw_ostream &OS) {
       continue;
 
     // Add VEX encoded instructions to one of VEXInsts vectors according to
-    // it's opcode.
+    // its opcode.
     if (Inst->TheDef->getValueAsDef("OpEnc")->getName() == "EncVEX") {
       uint64_t Opcode = getValueFromBitsInit(Inst->TheDef->
                                              getValueAsBitsInit("Opcode"));

--- a/src/mdl/jit/llvm/dist/utils/TableGen/X86FoldTablesEmitter.cpp
+++ b/src/mdl/jit/llvm/dist/utils/TableGen/X86FoldTablesEmitter.cpp
@@ -616,7 +616,7 @@ void X86FoldTablesEmitter::run(raw_ostream &OS) {
     auto Match = find_if(OpcRegInsts, IsMatch(MemInst, Records));
     if (Match != OpcRegInsts.end()) {
       const CodeGenInstruction *RegInst = *Match;
-      // If the matched instruction has it's "FoldGenRegForm" set, map the
+      // If the matched instruction has its "FoldGenRegForm" set, map the
       // memory form instruction to the register form instruction pointed by
       // this field
       if (RegInst->TheDef->isValueUnset("FoldGenRegForm")) {

--- a/src/mdl/jit/llvm/dist/utils/llvm-build/llvmbuild/main.py
+++ b/src/mdl/jit/llvm/dist/utils/llvm-build/llvmbuild/main.py
@@ -30,7 +30,7 @@ def cmake_quote_path(value):
     language files.
     """
 
-    # CMake has a bug in it's Makefile generator that doesn't properly quote
+    # CMake has a bug in its Makefile generator that doesn't properly quote
     # strings it generates. So instead of using proper quoting, we just use "/"
     # style paths.  Currently, we only handle escaping backslashes.
     value = value.replace("\\", "/")


### PR DESCRIPTION
The three HTML files in the one commit are the main thing, the rest are at your option.

Changes are "it's" to "its" where appropriate. Use "its" when you mean the possessive form, i.e., "it's good to use its diffuse component." Basically, if you can't substitute "it is" or "it has" for "it's" and have it still make sense, then you should be using "its" instead.

Little typo fixes, including using the US forms (e.g., "backward" and "toward" [are preferred](https://grammarist.com/usage/backward-vs-backwards/)). I gave up on trying to fix "backwards compatibility" in the code, which also uses "backward compatibility." I also didn't fix "vs" (I like spelling it out, "versus," or vs. if need be).

Anyway, with these fixes MDL is just that tiny bit better.