### PR TITLE
Fix two issues - build error with MSVC 2019 v16.6 and memory leak

### DIFF
--- a/src/io/scene/mdl_elements/mdl_elements_utilities.cpp
+++ b/src/io/scene/mdl_elements/mdl_elements_utilities.cpp
@@ -995,12 +995,12 @@ const IValue* lookup_sub_value(
             return 0;
         }
         ASSERT( M_SCENE, tail_type || !type);
-        const IValue* tail_value = value_struct->get_field( head.c_str());
-        if( !tail_value) {
+        mi::base::Handle<const IValue> tail_value(value_struct->get_field( head.c_str()));
+        if( !tail_value.is_valid_interface()) {
             if( sub_type) *sub_type = 0;
             return 0;
         }
-        return lookup_sub_value( tail_type, tail_value, tail.c_str(), sub_type);
+        return lookup_sub_value( tail_type, tail_value.get(), tail.c_str(), sub_type);
     }
 
     // handle other compounds via index

--- a/src/mdl/jit/llvm/dist/include/llvm/Support/ManagedStatic.h
+++ b/src/mdl/jit/llvm/dist/include/llvm/Support/ManagedStatic.h
@@ -33,18 +33,43 @@ template <typename T, size_t N> struct object_deleter<T[N]> {
   static void call(void *Ptr) { delete[](T *)Ptr; }
 };
 
+// ManagedStatic must be initialized to zero, and it must *not* have a dynamic
+// initializer because managed statics are often created while running other
+// dynamic initializers. In standard C++11, the best way to accomplish this is
+// with a constexpr default constructor. However, different versions of the
+// Visual C++ compiler have had bugs where, even though the constructor may be
+// constexpr, a dynamic initializer may be emitted depending on optimization
+// settings. For the affected versions of MSVC, use the old linker
+// initialization pattern of not providing a constructor and leaving the fields
+// uninitialized. See http://llvm.org/PR41367 for details.
+#if !defined(_MSC_VER) || (_MSC_VER >= 1925) || defined(__clang__)
+#define LLVM_USE_CONSTEXPR_CTOR
+#endif
+
 /// ManagedStaticBase - Common base class for ManagedStatic instances.
 class ManagedStaticBase {
 protected:
   // This should only be used as a static variable, which guarantees that this
   // will be zero initialized.
-  mutable std::atomic<void *> Ptr;
-  mutable void (*DeleterFn)(void*);
-  mutable const ManagedStaticBase *Next;
+#ifdef LLVM_USE_CONSTEXPR_CTOR
+    mutable std::atomic<void*> Ptr{};
+    mutable void (*DeleterFn)(void*) = nullptr;
+    mutable const ManagedStaticBase* Next = nullptr;
+#else
+  // This should only be used as a static variable, which guarantees that this
+  // will be zero initialized.
+    mutable std::atomic<void*> Ptr;
+    mutable void (*DeleterFn)(void*);
+    mutable const ManagedStaticBase* Next;
+#endif
 
   void RegisterManagedStatic(void *(*creator)(), void (*deleter)(void*)) const;
 
 public:
+#ifdef LLVM_USE_CONSTEXPR_CTOR
+    constexpr ManagedStaticBase() = default;
+#endif
+
   /// isConstructed - Return true if this object has not been created yet.
   bool isConstructed() const { return Ptr != nullptr; }
 

--- a/src/render/mdl/backends/backends_backends.cpp
+++ b/src/render/mdl/backends/backends_backends.cpp
@@ -1119,7 +1119,7 @@ public:
 
         // add all material parameters to the lambda function
         for (size_t i = 0, n = compiled_material->get_parameter_count(); i < n; ++i) {
-            MI::MDL::IValue const *value  = compiled_material->get_argument(i);
+            mi::base::Handle<const MI::MDL::IValue> value( compiled_material->get_argument(i));
             MI::MDL::IType const  *p_type = value->get_type();
 
             mi::mdl::IType const *tp = convert_type(main_df->get_type_factory(), p_type);


### PR DESCRIPTION
fix two issues:
* failed to build with MSVC 2019 v16.6
* has memory leak when call `mi::neuraylib::IMaterial_instance::create_compiled_material`