### PR TITLE
Fix compilation and spelling

### DIFF
--- a/examples/mdl/nvidia/sdk_examples/gun_metal.mdl
+++ b/examples/mdl/nvidia/sdk_examples/gun_metal.mdl
@@ -49,7 +49,7 @@ export material gun_metal (
     [[ 
         anno::display_name("Particle Size"), 
         anno::soft_range(0.0, 1.0),
-        anno::description("The size of the particles in millimeters. If the paticles don't appear "
+        anno::description("The size of the particles in millimeters. If the particles don't appear "
 		"at all, check whether you are using the correct units in yout scene. The materials is built to "
 		"use meters as scene unit")
     ]]

--- a/src/mdl/compiler/compilercore/compilercore_code_cache.cpp
+++ b/src/mdl/compiler/compilercore/compilercore_code_cache.cpp
@@ -26,6 +26,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *****************************************************************************/
 
+#include <cstdint>
+
 #include "pch.h"
 
 #include "compilercore_code_cache.h"

--- a/src/mdl/compiler/compilercore/compilercore_file_utils.cpp
+++ b/src/mdl/compiler/compilercore/compilercore_file_utils.cpp
@@ -37,6 +37,8 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
+#include <cctype>
+
 #ifndef MI_PLATFORM_WINDOWS
 #include <unistd.h>
 #include <dirent.h>

--- a/src/mdl/jit/llvm/dist/lib/Object/IRSymtab.cpp
+++ b/src/mdl/jit/llvm/dist/lib/Object/IRSymtab.cpp
@@ -348,7 +348,7 @@ static Expected<FileContents> upgrade(ArrayRef<BitcodeModule> BMs) {
   StringTableBuilder StrtabBuilder(StringTableBuilder::RAW);
   BumpPtrAllocator Alloc;
   if (Error E = build(Mods, FC.Symtab, StrtabBuilder, Alloc))
-    return std::move(E);
+    return E;
 
   StrtabBuilder.finalizeInOrder();
   FC.Strtab.resize(StrtabBuilder.getSize());
@@ -356,7 +356,7 @@ static Expected<FileContents> upgrade(ArrayRef<BitcodeModule> BMs) {
 
   FC.TheReader = {{FC.Symtab.data(), FC.Symtab.size()},
                   {FC.Strtab.data(), FC.Strtab.size()}};
-  return std::move(FC);
+  return FC;
 }
 
 Expected<FileContents> irsymtab::readBitcode(const BitcodeFileContents &BFC) {
@@ -390,5 +390,5 @@ Expected<FileContents> irsymtab::readBitcode(const BitcodeFileContents &BFC) {
   if (FC.TheReader.getNumModules() != BFC.Mods.size())
     return upgrade(std::move(BFC.Mods));
 
-  return std::move(FC);
+  return FC;
 }


### PR DESCRIPTION
I tried compiling on Ubuntu 20.10 (groovy) with clang-7/libllvm7/libffi7 installed from Ubuntu 20.04 (focal).
The g++ version is 10.2.

The following changes were necessary:
- compilercore_code_cache.cpp: include cstdint for uintptr_t.
- compilercore_file_utils.cpp: include cctype for isdigit.

I found the following spelling error:
- /paticles/particles in gun_metal.mdl.