### PR TITLE
fixing potential NANs in complex_ior_fresnel

### DIFF
--- a/src/mdl/jit/libbsdf/libbsdf_utilities.h
+++ b/src/mdl/jit/libbsdf/libbsdf_utilities.h
@@ -329,7 +329,7 @@ BSDF_INLINE float complex_ior_fresnel(
     const float t0 = eta2 - eta_k2 - sintheta2;
     const float a2plusb2 = math::sqrt(t0 * t0 + 4.0f * eta2 * eta_k2);
     const float t1 = a2plusb2 + costheta2;
-    const float a = math::sqrt(0.5f * (a2plusb2 + t0));
+    const float a = math::sqrt(math::max(0.5f * (a2plusb2 + t0), 0.f));
     const float t2 = 2.0f * a * costheta;
     const float rs = (t1 - t2) / (t1 + t2);
 


### PR DESCRIPTION
sometimes occurs if eta_k == 0.0

example of specific breaking input into complex_ior_fresnel (CUDA with fastmath)
eta = 0.4000000059604644775390625000000000000000f
eta_k = 0.0000000000000000000000000000000000000000f 
costheta = 0.8029893636703491210937500000000000000000f