### PR TITLE
Fix memory leak Issues In Mdl_material_library of mi::examples::mdl_d3d12

### DIFF
--- a/examples/mdl_sdk/dxr/mdl_d3d12/mdl_material_library.h
+++ b/examples/mdl_sdk/dxr/mdl_d3d12/mdl_material_library.h
@@ -60,13 +60,27 @@ namespace mi { namespace examples { namespace mdl_d3d12
 
         struct Target_entry
         {
+            // Empty constructor for stl containers
+            Target_entry() {};
+
             // Constructor.
             explicit Target_entry(Mdl_material_target* target);
+
+            // Move constructor for stl containers
+            Target_entry(Target_entry&& other) noexcept
+            {
+                // Lock until the target is ready for move operation
+                std::unique_lock<std::mutex> lock(other.m_mutex);
+
+                // Swap the target pointer
+                m_target = other.m_target;
+                other.m_target = nullptr;
+            }
 
             // Destructor.
             ~Target_entry();
 
-            Mdl_material_target* m_target;
+            Mdl_material_target* m_target = nullptr;
             std::mutex m_mutex;
         };
 
@@ -191,7 +205,7 @@ namespace mi { namespace examples { namespace mdl_d3d12
 
         // map that stores targets based on the compiled material hash
         std::map<size_t, Mdl_material_target*> m_targets;
-        std::map<std::string, Target_entry*> m_target_map;
+        std::map<std::string, Target_entry> m_target_map;
         std::mutex m_targets_mtx;
 
         // all texture resources used by MDL materials


### PR DESCRIPTION
### Issue

1. The object lifetime of Target_entry is dynamically allocated on heap see [here](https://github.com/NVIDIA/MDL-SDK/blob/9837d3593c8a5861ea61018d5248f0b2d704b0b8/examples/mdl_sdk/dxr/mdl_d3d12/mdl_material_library.cpp#L96).
2. However whenever the key of m_target_map is released, the value (pointer of Target_entry )of m_target_map would not, 
see [here](https://github.com/NVIDIA/MDL-SDK/blob/9837d3593c8a5861ea61018d5248f0b2d704b0b8/examples/mdl_sdk/dxr/mdl_d3d12/mdl_material_library.cpp#L149),[here](https://github.com/NVIDIA/MDL-SDK/blob/9837d3593c8a5861ea61018d5248f0b2d704b0b8/examples/mdl_sdk/dxr/mdl_d3d12/mdl_material_library.cpp#L224),[here ](https://github.com/NVIDIA/MDL-SDK/blob/9837d3593c8a5861ea61018d5248f0b2d704b0b8/examples/mdl_sdk/dxr/mdl_d3d12/mdl_material_library.cpp#L432)
and most deadly [here](https://github.com/NVIDIA/MDL-SDK/blob/9837d3593c8a5861ea61018d5248f0b2d704b0b8/examples/mdl_sdk/dxr/mdl_d3d12/mdl_material_library.cpp#L75)
3. Result with adding crtdbg configure on Windows for dxr example: 
![image](https://user-images.githubusercontent.com/3478925/184714389-ab1aa672-229c-4a6e-9066-cc309497c3e8.png)

### Solution
1) As Target_entry is basically a thin wrapper of  Mdl_material_target with mutex and also it controls the lifetime of Mdl_material_target, so value type to be used for m_target_map is recommanded.

2) To solve the moving operations due to usage of value type is to adjust move constructor to have the ownership of rhs from moving by having a lock before moving actually happen. 

3) Mdl_material_target::m_targets will no longer handle the Mdl_material_target* lifetime by itself, as it is just a member of Target_entry which has the responsibility to control Mdl_material_target 's life time.