### PR TITLE
ensuring complex_ior_fresnel() always returns a valid result

### DIFF
--- a/src/mdl/jit/libbsdf/libbsdf_utilities.h
+++ b/src/mdl/jit/libbsdf/libbsdf_utilities.h
@@ -474,7 +474,7 @@ BSDF_INLINE float complex_ior_fresnel(
     const float t4 = t2 * sintheta2;
     const float rp = rs * (t3 - t4) / (t3 + t4);
 
-    return 0.5f * (rp + rs);
+    return math::saturate(0.5f * (rp + rs));
 }
 
 BSDF_INLINE float3 complex_ior_fresnel(


### PR DESCRIPTION
the complex_ior_fresnel function can sometimes produce a negative result
eg
complex_ior_fresnel( 1.0f, 0.0f, 0.670869052f ) produces -1.67196e-08

this change clamps the final result to valid range.

