### PR TITLE
fixing TIR in microfacet_evaluate() (regression from 359000.2512)

### DIFF
--- a/src/mdl/jit/libbsdf/libbsdf.cpp
+++ b/src/mdl/jit/libbsdf/libbsdf.cpp
@@ -918,10 +918,14 @@ BSDF_INLINE float3 microfacet_evaluate(
                 if (!is_tir(ior, k1h)) {
                     absorb(data);
                     return make<float3>(0.0f);
+                } else {
+                    f_refl_c = make<float3>(1.0f);
+                    f_refl = 1.0f;
                 }
+            } else {
+                f_refl_c = make<float3>(0.0f);
+                f_refl = 0.0f;
             }
-            f_refl_c = make<float3>(0.0f);
-            f_refl = 0.0f;
             break;
         case scatter_reflect_transmit:
             {


### PR DESCRIPTION
microfacet_evaluate() produces black/zero for TIR, which seems to be a regression from 359000.2512 (ie previous versions worked fine).  This commit fixes it.